### PR TITLE
Remove this mixing. Its the same as using align() from jeet

### DIFF
--- a/assets/styles/helpers/_mixins.scss
+++ b/assets/styles/helpers/_mixins.scss
@@ -82,25 +82,3 @@
     @content;
   }
 }
-
-// ----- Absolutelly center blocks ----- //
-@mixin center-block($orientation: all) {
-  position: relative;
-
-  @if ($orientation == all) {
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
-  @elseif ($orientation == vertical) {
-    top: 50%;
-    left: auto;
-    transform: translate(0, -50%);
-  }
-  @elseif ($orientation == horizontal) {
-    top: auto;
-    left: 50%;
-    transform: translate(-50%, 0);
-  }
-
-}


### PR DESCRIPTION
Its the same as using align() from jeet
you can align horizontally and vertically, and both ways

instead of using 'all' as a parameter, use 'both'