### PR TITLE
Refactored star rating component

### DIFF
--- a/assets/styles/modules/_ratings.scss
+++ b/assets/styles/modules/_ratings.scss
@@ -7,7 +7,7 @@
 @import "../libs/sassy-cast/SassyCast";
 
 ///
-$rating-type:            "clickeable" !default;
+$rating-type:            "clickable" !default;
 ///
 $rating-color-empty:     #ccc !default;
 ///
@@ -38,7 +38,7 @@ $rating-icon-names: (
 /// on a data-attribute value.
 /// JS logic behing this component should
 /// round up values per quarter.
-/// @param {string} $rating-type ["clickeable"] - Indicates if whether this component should be clickeable (clickeable) or just representative (representative).
+/// @param {string} $rating-type ["clickable"] - Indicates if whether this component should be clickable (clickable) or just representative (representative).
 /// @example
 ///   <div class="c-rating" data-rating-value="3.25">
 ///     <button></button>
@@ -75,7 +75,7 @@ $rating-icon-names: (
         margin-left: 0;
       }
 
-      @if $type == "clickeable" {
+      @if $type == "clickable" {
         &:hover,
         &:hover ~ button {
           color: $rating-color-empty !important;
@@ -87,7 +87,7 @@ $rating-icon-names: (
       }
     }
 
-    @if $type == "clickeable" {
+    @if $type == "clickable" {
       &:hover {
         button {
           color: $rating-color-hover !important;

--- a/assets/styles/modules/_ratings.scss
+++ b/assets/styles/modules/_ratings.scss
@@ -7,9 +7,15 @@
 @import "../libs/sassy-cast/SassyCast";
 
 ///
+$rating-type:            "clickeable" !default;
+///
 $rating-color-empty:     #ccc !default;
 ///
 $rating-color-full:      gold !default;
+///
+$rating-color-hover:     grey !default;
+///
+$rating-star-spacing:    3px !default;
 ///
 $rating-values: (
   '0.25', '0.50', '0.75', '1.00',
@@ -26,35 +32,71 @@ $rating-icon-names: (
   'full': '.icon-star-full'
 );
 
-
-/// Star Rating Component - 
+/// Star Rating Component -
 /// This is a CSS-only star rating component
 /// that shows the proper rating depending
 /// on a data-attribute value.
+/// JS logic behing this component should
+/// round up values per quarter.
+/// @param {string} $rating-type ["clickeable"] - Indicates if whether this component should be clickeable (clickeable) or just representative (representative).
 /// @example
 ///   <div class="c-rating" data-rating-value="3.25">
-///     <span></span>
-///     <span></span>
-///     <span></span>
-///     <span></span>
-///     <span></span>
+///     <button></button>
+///     <button></button>
+///     <button></button>
+///     <button></button>
+///     <button></button>
 ///   </div>
-@mixin c-rating{
+
+@mixin c-rating($type: $rating-type) {
   .c-rating {
+    @include clearfix();
+
     display: inline-block;
 
-    span {
+    @if $type == "representative" {
+      pointer-events: none;
+    }
+
+    button {
       @extend .ms-icon;
       @extend #{map-get($rating-icon-names, 'full')};
 
       position: relative;
-      margin: 0 3px;
+      float: left;
+      padding: 0 $rating-star-spacing;
       font-size: toem(16px);
       color: $rating-color-empty;
+      background-color: transparent;
+      border: none;
       transition: color $msuif-transition-duration $msuif-transition-timing;
 
       &:first-child {
         margin-left: 0;
+      }
+
+      @if $type == "clickeable" {
+        &:hover,
+        &:hover ~ button {
+          color: $rating-color-empty !important;
+
+          &:after {
+            color: $rating-color-empty !important;
+          }
+        }
+      }
+    }
+
+    @if $type == "clickeable" {
+      &:hover {
+        button {
+          color: $rating-color-hover !important;
+          transition: none;
+
+          &:after {
+            color: $rating-color-hover !important;
+          }
+        }
       }
     }
 
@@ -63,11 +105,11 @@ $rating-icon-names: (
       $rating-value-ceil: ceil(to-number($rating-value));
 
       &[data-rating-value="#{unquote($rating-value)}"] {
-        span:nth-child(-n+#{$rating-value-ceil}) {
+        button:nth-child(-n+#{$rating-value-ceil}) {
           color: $rating-color-full;
         }
 
-        span:nth-child(#{$rating-value-ceil}) {
+        button:nth-child(#{$rating-value-ceil}) {
           @if explode($rating-value, '.') == '.25' {
             @extend #{map-get($rating-icon-names, 'quarter')};
           }
@@ -85,8 +127,9 @@ $rating-icon-names: (
 
           &:after {
             @extend .icon-star-full:before;
+
             position: absolute;
-            left: 0;
+            left: $rating-star-spacing;
             z-index: 0;
             color: $rating-color-empty;
           }


### PR DESCRIPTION
Hey guys, here's another refactoring that needed to get done.
In this case, the refactor was to provide 2 different options passed as a mixing parameter to indicate if the component is just to represent values or should be clickeable/hoverable.
There are a couple of `!important` declarations that are there to overcome specificity created by targeting the different `data-attribute` values. This can be refactored, but the resulting CSS was **huge** for a single component.
 Anyway, those blocks are being printed if the `$rating-type` variable is set to `clickeable` only.